### PR TITLE
feat: Update workflow to use artifact naming convention

### DIFF
--- a/.github/workflows/svg-generator.yml
+++ b/.github/workflows/svg-generator.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Upload generated snakes SVGs as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: svg-artifacts
+          name: svg-artifacts-snakes
           path: ./img
 
   download-images:
@@ -115,7 +115,7 @@ jobs:
       - name: Upload downloaded SVGs as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: svg-artifacts
+          name: svg-artifacts-stats
           path: ./img
 
   commit-and-push:
@@ -133,7 +133,8 @@ jobs:
       - name: Download SVGs from artifacts
         uses: actions/download-artifact@v4
         with:
-          name: svg-artifacts
+          pattern: svg-artifacts-* # Download all artifacts that start with 'svg-artifacts-'
+          merge-multiple: true
           path: ./img
 
       # Commit and push the SVGs to the repository


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/svg-generator.yml` file to improve the naming and handling of SVG artifacts. The most important changes involve renaming artifact names to be more descriptive and updating the download step to handle multiple artifacts.

Artifact naming improvements:

* [`.github/workflows/svg-generator.yml`](diffhunk://#diff-5d1cd6d24cfa7c4957f3e03e436cf886d7230a7305e737303ee74e51f116fcbbL55-R55): Renamed the artifact name from `svg-artifacts` to `svg-artifacts-snakes` for the upload of generated snake SVGs.
* [`.github/workflows/svg-generator.yml`](diffhunk://#diff-5d1cd6d24cfa7c4957f3e03e436cf886d7230a7305e737303ee74e51f116fcbbL118-R118): Renamed the artifact name from `svg-artifacts` to `svg-artifacts-stats` for the upload of downloaded SVGs.

Artifact handling improvements:

* [`.github/workflows/svg-generator.yml`](diffhunk://#diff-5d1cd6d24cfa7c4957f3e03e436cf886d7230a7305e737303ee74e51f116fcbbL136-R137): Updated the download step to use a pattern `svg-artifacts-*` to download all relevant artifacts and enabled merging of multiple artifacts.